### PR TITLE
feat: redesign admin UI with dark sidebar and modern dashboard

### DIFF
--- a/lib/core/presentation/admin_layout.dart
+++ b/lib/core/presentation/admin_layout.dart
@@ -1,0 +1,276 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:sanalink/core/auth/auth_service.dart';
+import 'package:sanalink/theme/theme_provider.dart';
+
+/// Shell layout for Admin users.
+/// Replaces [MainLayout] with a dark sidebar and a clean content area.
+class AdminLayout extends ConsumerWidget {
+  final Widget child;
+  const AdminLayout({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentPath = GoRouterState.of(context).uri.path;
+    return Scaffold(
+      backgroundColor: const Color(0xFFF4F5F7),
+      body: Row(
+        children: [
+          _AdminSidebar(currentPath: currentPath),
+          const VerticalDivider(width: 1, thickness: 1, color: Color(0xFFE2E8F0)),
+          Expanded(child: child),
+        ],
+      ),
+    );
+  }
+}
+
+// ─── Navigation data ──────────────────────────────────────────────────────
+
+class _NavItem {
+  final String label;
+  final IconData icon;
+  final String route;
+  const _NavItem(this.label, this.icon, this.route);
+}
+
+class _NavSection {
+  final String? header;
+  final List<_NavItem> items;
+  const _NavSection({this.header, required this.items});
+}
+
+final _navSections = [
+  _NavSection(items: [
+    _NavItem('Tableau de bord', Icons.dashboard_rounded, '/dashboard'),
+  ]),
+  _NavSection(header: 'Administration', items: [
+    _NavItem('Personnel', Icons.people_rounded, '/admin/staff'),
+    _NavItem('Établissements', Icons.business_rounded, '/admin/facilities'),
+  ]),
+  _NavSection(header: 'Modules', items: [
+    _NavItem('Consultations', Icons.calendar_today_rounded, '/encounters'),
+    _NavItem('Laboratoire', Icons.science_rounded, '/lab/orders'),
+    _NavItem('Pharmacie', Icons.local_pharmacy_rounded, '/pharmacy/dispense'),
+  ]),
+];
+
+// ─── Sidebar ──────────────────────────────────────────────────────────────
+
+class _AdminSidebar extends ConsumerWidget {
+  final String currentPath;
+  const _AdminSidebar({required this.currentPath});
+
+  static const _bg = Color(0xFF1B2559);
+  static const _divider = Color(0xFF2D3A8C);
+  static const _muted = Color(0xFFADB5C8);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final themeMode = ref.watch(themeProvider);
+
+    return Container(
+      width: 240,
+      color: _bg,
+      child: Column(
+        children: [
+          // ── Logo ──────────────────────────────────────────────────────
+          Container(
+            height: 64,
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(8),
+                  decoration: BoxDecoration(
+                    color: Colors.white.withValues(alpha: 0.15),
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: const Icon(Icons.local_hospital,
+                      color: Colors.white, size: 20),
+                ),
+                const SizedBox(width: 12),
+                const Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Sanalink',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontWeight: FontWeight.w900,
+                          fontSize: 16,
+                          letterSpacing: 0.5,
+                        )),
+                    Text('Admin Console',
+                        style: TextStyle(color: _muted, fontSize: 11)),
+                  ],
+                ),
+              ],
+            ),
+          ),
+
+          const Divider(color: _divider, height: 1),
+
+          // ── Nav items ─────────────────────────────────────────────────
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              children: _navSections.expand((section) sync* {
+                if (section.header != null) {
+                  yield Padding(
+                    padding: const EdgeInsets.fromLTRB(20, 16, 20, 6),
+                    child: Text(
+                      section.header!.toUpperCase(),
+                      style: const TextStyle(
+                        color: _muted,
+                        fontSize: 10,
+                        fontWeight: FontWeight.w600,
+                        letterSpacing: 1.2,
+                      ),
+                    ),
+                  );
+                }
+                for (final item in section.items) {
+                  yield _NavTile(
+                    item: item,
+                    isSelected: currentPath.startsWith(item.route),
+                  );
+                }
+              }).toList(),
+            ),
+          ),
+
+          // ── Bottom actions ────────────────────────────────────────────
+          const Divider(color: _divider, height: 1),
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: Column(
+              children: [
+                _SidebarAction(
+                  icon: themeMode == ThemeMode.dark
+                      ? Icons.light_mode_rounded
+                      : Icons.dark_mode_rounded,
+                  label: themeMode == ThemeMode.dark
+                      ? 'Mode clair'
+                      : 'Mode sombre',
+                  onTap: () =>
+                      ref.read(themeProvider.notifier).toggleTheme(),
+                ),
+                _SidebarAction(
+                  icon: Icons.logout_rounded,
+                  label: 'Déconnexion',
+                  color: Colors.redAccent,
+                  onTap: () =>
+                      ref.read(authServiceProvider.notifier).logout(),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ─── Nav tile ─────────────────────────────────────────────────────────────
+
+class _NavTile extends StatelessWidget {
+  final _NavItem item;
+  final bool isSelected;
+  const _NavTile({required this.item, required this.isSelected});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+      child: Material(
+        color: isSelected
+            ? const Color(0xFF2D3A8C)
+            : Colors.transparent,
+        borderRadius: BorderRadius.circular(10),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(10),
+          onTap: () => context.go(item.route),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            child: Row(
+              children: [
+                Icon(
+                  item.icon,
+                  size: 18,
+                  color: isSelected
+                      ? Colors.white
+                      : const Color(0xFFADB5C8),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    item.label,
+                    style: TextStyle(
+                      color: isSelected
+                          ? Colors.white
+                          : const Color(0xFFADB5C8),
+                      fontSize: 13,
+                      fontWeight: isSelected
+                          ? FontWeight.w600
+                          : FontWeight.normal,
+                    ),
+                  ),
+                ),
+                if (isSelected)
+                  Container(
+                    width: 6,
+                    height: 6,
+                    decoration: const BoxDecoration(
+                      color: Colors.white,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Bottom sidebar action ────────────────────────────────────────────────
+
+class _SidebarAction extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final VoidCallback onTap;
+  final Color? color;
+  const _SidebarAction({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final c = color ?? const Color(0xFFADB5C8);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+      child: Material(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(10),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(10),
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+            child: Row(children: [
+              Icon(icon, size: 18, color: c),
+              const SizedBox(width: 12),
+              Text(label, style: TextStyle(color: c, fontSize: 13)),
+            ]),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/presentation/main_layout.dart
+++ b/lib/core/presentation/main_layout.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sanalink/core/auth/auth_service.dart';
+import 'package:sanalink/core/presentation/admin_layout.dart';
 import 'package:sanalink/theme/app_theme.dart';
 import 'package:sanalink/theme/theme_provider.dart';
 
@@ -16,6 +17,8 @@ class MainLayout extends ConsumerWidget {
     final authState = ref.watch(authServiceProvider).value;
     final user = authState?.user;
     final role = user?.role ?? '';
+
+    if (role == 'Admin') return AdminLayout(child: child);
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/features/dashboard/presentation/dashboard_screen.dart
+++ b/lib/features/dashboard/presentation/dashboard_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sanalink/core/auth/auth_service.dart';
 import 'package:sanalink/features/dashboard/presentation/analytics_charts.dart';
 import 'package:sanalink/features/dashboard/providers/dashboard_providers.dart';
 import 'package:sanalink/models/encounter_model.dart';
@@ -8,156 +9,244 @@ import 'package:sanalink/theme/app_theme.dart';
 class DashboardScreen extends ConsumerWidget {
   const DashboardScreen({super.key});
 
+  void _refresh(WidgetRef ref) {
+    ref.invalidate(appointmentAnalyticsProvider);
+    ref.invalidate(activeStaffCountProvider);
+    ref.invalidate(recentEncountersProvider);
+    ref.invalidate(encounterAnalyticsProvider);
+    ref.invalidate(appointmentsPerDayProvider);
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final analyticsAsync = ref.watch(appointmentAnalyticsProvider);
     final staffAsync = ref.watch(activeStaffCountProvider);
     final encountesAsync = ref.watch(recentEncountersProvider);
+    final user = ref.watch(authServiceProvider).value?.user;
+    final isAdmin = user?.role == 'Admin';
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text(
-          'Tableau de bord',
-          style: TextStyle(fontWeight: FontWeight.bold),
-        ),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.refresh),
-            onPressed: () {
-              ref.invalidate(appointmentAnalyticsProvider);
-              ref.invalidate(activeStaffCountProvider);
-              ref.invalidate(recentEncountersProvider);
-              ref.invalidate(encounterAnalyticsProvider);
-              ref.invalidate(appointmentsPerDayProvider);
-            },
-          ),
-        ],
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(24.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'Aperçu de la journée',
-              style: Theme.of(context).textTheme.headlineSmall
-                  ?.copyWith(fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: 24),
-            analyticsAsync.when(
-              data: (analytics) => _buildStatsGrid(context, analytics),
-              loading: () => const Center(child: CircularProgressIndicator()),
-              error: (_, __) => _buildStatsGrid(
-                  context, AppointmentAnalytics.empty),
-            ),
-            const SizedBox(height: 32),
+    final body = SingleChildScrollView(
+      padding: const EdgeInsets.all(28.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // ── Page header ───────────────────────────────────────────────
+          if (isAdmin) ...[
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Expanded(
-                  flex: 2,
-                  child: Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const Text(
-                            'Consultations récentes',
-                            style: TextStyle(
-                              fontSize: 18,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                          const Divider(),
-                          encountesAsync.when(
-                            data: (encounters) => encounters.isEmpty
-                                ? const Padding(
-                                    padding: EdgeInsets.all(16),
-                                    child: Text('Aucune consultation trouvée.'),
-                                  )
-                                : Column(
-                                    children: encounters
-                                        .map((e) =>
-                                            _buildEncounterTile(e))
-                                        .toList(),
-                                  ),
-                            loading: () => const Padding(
-                              padding: EdgeInsets.all(16),
-                              child: CircularProgressIndicator(),
-                            ),
-                            error: (_, __) => const Padding(
-                              padding: EdgeInsets.all(16),
-                              child: Text('Impossible de charger les consultations.'),
-                            ),
-                          ),
-                        ],
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Tableau de bord',
+                        style: Theme.of(context)
+                            .textTheme
+                            .headlineMedium
+                            ?.copyWith(fontWeight: FontWeight.bold),
                       ),
-                    ),
+                      const SizedBox(height: 4),
+                      Text(
+                        'Bienvenue, ${user?.firstName ?? ''} — voici l\'aperçu du système.',
+                        style: TextStyle(
+                          color: Colors.grey[600],
+                          fontSize: 14,
+                        ),
+                      ),
+                    ],
                   ),
                 ),
-                const SizedBox(width: 16),
-                Expanded(
-                  flex: 1,
-                  child: Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const Text(
-                            'Personnel actif',
-                            style: TextStyle(
-                              fontSize: 18,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                          const Divider(),
-                          staffAsync.when(
-                            data: (staff) => Column(
-                              children: [
-                                ListTile(
-                                  leading: const CircleAvatar(
-                                    backgroundColor: Colors.blue,
-                                    child: Icon(Icons.medical_services,
-                                        color: Colors.white, size: 18),
-                                  ),
-                                  title: Text('${staff.doctors} Médecin(s)'),
-                                  subtitle: const Text('Actif(s)'),
-                                ),
-                                ListTile(
-                                  leading: const CircleAvatar(
-                                    backgroundColor: Colors.green,
-                                    child: Icon(Icons.healing,
-                                        color: Colors.white, size: 18),
-                                  ),
-                                  title: Text('${staff.nurses} Infirmier(s)'),
-                                  subtitle: const Text('Actif(s)'),
-                                ),
-                              ],
-                            ),
-                            loading: () => const Center(
-                                child: CircularProgressIndicator()),
-                            error: (_, __) =>
-                                const Text('Données indisponibles'),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
+                IconButton.outlined(
+                  icon: const Icon(Icons.refresh_rounded),
+                  tooltip: 'Actualiser',
+                  onPressed: () => _refresh(ref),
                 ),
               ],
             ),
-            const SizedBox(height: 32),
-            const AnalyticsChartsSection(),
+            const SizedBox(height: 28),
+          ] else ...[
+            const SizedBox(height: 8),
           ],
-        ),
+
+          // ── Stat cards ────────────────────────────────────────────────
+          analyticsAsync.when(
+            data: (analytics) => _buildStatsGrid(context, analytics, isAdmin),
+            loading: () =>
+                const Center(child: CircularProgressIndicator()),
+            error: (_, __) =>
+                _buildStatsGrid(context, AppointmentAnalytics.empty, isAdmin),
+          ),
+          const SizedBox(height: 28),
+
+          // ── Recent encounters + active staff ──────────────────────────
+          LayoutBuilder(builder: (context, constraints) {
+            final wide = constraints.maxWidth > 700;
+            final encounterCard = Card(
+              child: Padding(
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.receipt_long_rounded,
+                            size: 18, color: AppTheme.primaryColor),
+                        const SizedBox(width: 8),
+                        const Text('Consultations récentes',
+                            style: TextStyle(
+                                fontSize: 15,
+                                fontWeight: FontWeight.bold)),
+                      ],
+                    ),
+                    const Divider(height: 20),
+                    encountesAsync.when(
+                      data: (encounters) => encounters.isEmpty
+                          ? const Padding(
+                              padding: EdgeInsets.all(16),
+                              child: Text('Aucune consultation trouvée.'),
+                            )
+                          : Column(
+                              children: encounters
+                                  .map(_buildEncounterTile)
+                                  .toList(),
+                            ),
+                      loading: () => const Padding(
+                        padding: EdgeInsets.all(16),
+                        child: CircularProgressIndicator(),
+                      ),
+                      error: (_, __) => const Padding(
+                        padding: EdgeInsets.all(16),
+                        child:
+                            Text('Impossible de charger les consultations.'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            );
+
+            final staffCard = Card(
+              child: Padding(
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        const Icon(Icons.people_rounded,
+                            size: 18, color: AppTheme.primaryColor),
+                        const SizedBox(width: 8),
+                        const Text('Personnel actif',
+                            style: TextStyle(
+                                fontSize: 15,
+                                fontWeight: FontWeight.bold)),
+                      ],
+                    ),
+                    const Divider(height: 20),
+                    staffAsync.when(
+                      data: (staff) => Column(
+                        children: [
+                          _StaffTile(
+                            icon: Icons.medical_services_rounded,
+                            color: Colors.blue,
+                            label: 'Médecin(s)',
+                            count: staff.doctors,
+                          ),
+                          const SizedBox(height: 8),
+                          _StaffTile(
+                            icon: Icons.healing_rounded,
+                            color: Colors.green,
+                            label: 'Infirmier(s)',
+                            count: staff.nurses,
+                          ),
+                        ],
+                      ),
+                      loading: () => const Center(
+                          child: CircularProgressIndicator()),
+                      error: (_, __) =>
+                          const Text('Données indisponibles'),
+                    ),
+                  ],
+                ),
+              ),
+            );
+
+            if (wide) {
+              return Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(flex: 2, child: encounterCard),
+                  const SizedBox(width: 16),
+                  Expanded(flex: 1, child: staffCard),
+                ],
+              );
+            }
+            return Column(children: [
+              encounterCard,
+              const SizedBox(height: 16),
+              staffCard,
+            ]);
+          }),
+
+          const SizedBox(height: 28),
+          const AnalyticsChartsSection(),
+        ],
       ),
+    );
+
+    if (isAdmin) {
+      return Scaffold(backgroundColor: Colors.transparent, body: body);
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Tableau de bord',
+            style: TextStyle(fontWeight: FontWeight.bold)),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () => _refresh(ref),
+          ),
+        ],
+      ),
+      body: body,
     );
   }
 
   Widget _buildStatsGrid(
-      BuildContext context, AppointmentAnalytics analytics) {
+      BuildContext context, AppointmentAnalytics analytics, bool isAdmin) {
+    final cards = [
+      _StatCard(
+        title: 'Total Consultations',
+        value: '${analytics.totalAppointments}',
+        icon: Icons.calendar_month_rounded,
+        color: AppTheme.primaryColor,
+        isAdmin: isAdmin,
+      ),
+      _StatCard(
+        title: 'Rendez-vous programmés',
+        value: '${analytics.scheduled}',
+        icon: Icons.event_available_rounded,
+        color: Colors.orange,
+        isAdmin: isAdmin,
+      ),
+      _StatCard(
+        title: 'Prescriptions émises',
+        value: '${analytics.totalPrescriptions}',
+        icon: Icons.medication_rounded,
+        color: Colors.purple,
+        isAdmin: isAdmin,
+      ),
+      _StatCard(
+        title: 'Patients enregistrés',
+        value: '${analytics.totalPatients}',
+        icon: Icons.person_add_alt_1_rounded,
+        color: Colors.teal,
+        isAdmin: isAdmin,
+      ),
+    ];
+
     return LayoutBuilder(
       builder: (context, constraints) {
         final crossAxisCount = constraints.maxWidth > 1200
@@ -171,33 +260,8 @@ class DashboardScreen extends ConsumerWidget {
           physics: const NeverScrollableScrollPhysics(),
           crossAxisSpacing: 16,
           mainAxisSpacing: 16,
-          childAspectRatio: 1.5,
-          children: [
-            _StatCard(
-              title: 'Total Consultations',
-              value: '${analytics.totalAppointments}',
-              icon: Icons.calendar_month,
-              color: AppTheme.primaryColor,
-            ),
-            _StatCard(
-              title: 'Rendez-vous programmés',
-              value: '${analytics.scheduled}',
-              icon: Icons.people_outline,
-              color: Colors.orange,
-            ),
-            _StatCard(
-              title: 'Prescriptions actives',
-              value: '${analytics.totalPrescriptions}',
-              icon: Icons.medication,
-              color: Colors.purple,
-            ),
-            _StatCard(
-              title: 'Patients enregistrés',
-              value: '${analytics.totalPatients}',
-              icon: Icons.person_add_alt_1,
-              color: AppTheme.errorColor,
-            ),
-          ],
+          childAspectRatio: isAdmin ? 1.6 : 1.5,
+          children: cards,
         );
       },
     );
@@ -236,16 +300,70 @@ class _StatCard extends StatelessWidget {
   final String value;
   final IconData icon;
   final Color color;
+  final bool isAdmin;
 
   const _StatCard({
     required this.title,
     required this.value,
     required this.icon,
     required this.color,
+    this.isAdmin = false,
   });
 
   @override
   Widget build(BuildContext context) {
+    if (isAdmin) {
+      return Card(
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+          side: BorderSide(color: Colors.grey.withValues(alpha: 0.12)),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Text(
+                      title,
+                      style: TextStyle(
+                        color: Colors.grey[600],
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: const EdgeInsets.all(10),
+                    decoration: BoxDecoration(
+                      color: color.withValues(alpha: 0.12),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Icon(icon, color: color, size: 20),
+                  ),
+                ],
+              ),
+              Text(
+                value,
+                style: const TextStyle(
+                  fontSize: 30,
+                  fontWeight: FontWeight.bold,
+                  letterSpacing: -0.5,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Default style for non-admin roles
     return Card(
       elevation: 2,
       child: Padding(
@@ -279,6 +397,58 @@ class _StatCard extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+// ─── Staff tile used in the personnel actif card ──────────────────────────
+
+class _StaffTile extends StatelessWidget {
+  final IconData icon;
+  final Color color;
+  final String label;
+  final int count;
+  const _StaffTile({
+    required this.icon,
+    required this.color,
+    required this.label,
+    required this.count,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.07),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(icon, color: color, size: 16),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(label,
+                style: const TextStyle(
+                    fontSize: 13, fontWeight: FontWeight.w500)),
+          ),
+          Text(
+            '$count',
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: color,
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
- New AdminLayout with dark navy sidebar (#1B2559), grouped nav sections, theme toggle and logout at the bottom
- MainLayout now delegates to AdminLayout for the Admin role
- DashboardScreen: admin view has welcome greeting, borderless stat cards with colored icon boxes, transparent Scaffold to show admin bg